### PR TITLE
Collapse with checkbox

### DIFF
--- a/components/Example.js
+++ b/components/Example.js
@@ -25,6 +25,7 @@ export const Example = ({ path, cat, desc }) => {
           tabIndex={0}
           className="collapse collapse-arrow border border-base-300 bg-base-100 rounded-box mt-8"
         >
+          <input type="checkbox" />
           <div className="collapse-title font-medium">
             See available categories
           </div>


### PR DESCRIPTION
Not knowing if this was made on propose, here's a quick "fix" so the collapsible element can return to the original form on element click as well, instead of clicking "outside" 

from [DaisyUI docs](https://daisyui.com/components/collapse/#collapse-with-checkbox)

![msedge_7wcOi2hT05](https://user-images.githubusercontent.com/45473/220758127-2ff543bd-c9c7-4336-8d63-80f9e9be5b72.gif)
